### PR TITLE
fix downscale-http-path reference

### DIFF
--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -21,7 +21,7 @@ metadata:
   annotations:
     {{- include "mimir.componentAnnotations" $args | nindent 4 }}
     {{- if $rolloutZone.prepareDownscale }}
-    grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
     grafana.com/prepare-downscale-http-port: {{ include "mimir.serverHttpListenPort" . }}
     {{- end -}}
     {{- if $rolloutZone.downscaleLeader }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

#### What this PR does

This PR fixes a reference to ingester in the store-gateway StatefulSet template. It was a suggested change on the open Mimir PR.

```
-    grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
+   grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
```

#### Which issue(s) this PR fixes or relates to

Fixes [#6733](https://github.com/grafana/mimir/pull/6733)

#### Checklist

- [ ] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
