### PR TITLE
Additional revisions to fix helm manifest error

### DIFF
--- a/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -12,18 +12,14 @@ metadata:
   labels:
     {{- include "mimir.labels" $args | nindent 4 }}
     {{- if (eq $rolloutZone.noDownscale true )}}
-    grafana.com/no-downscale: {{$rolloutZone.noDownscale}}
+    grafana.com/no-downscale: {{ $rolloutZone.noDownscale | quote }}
     {{- else }}
     {{- if (eq $rolloutZone.prepareDownscale true )}}
-    grafana.com/prepare-downscale: {{$rolloutZone.prepareDownscale}}
+    grafana.com/prepare-downscale: {{ $rolloutZone.prepareDownscale | quote }}
     {{- end }}
     {{- end }}
   annotations:
     {{- include "mimir.componentAnnotations" $args | nindent 4 }}
-    {{- if $rolloutZone.prepareDownscale }}
-    grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: {{ include "mimir.serverHttpListenPort" . }}
-    {{- end -}}
     {{- if $rolloutZone.downscaleLeader }}
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
     {{- end }}

--- a/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -11,10 +11,10 @@ metadata:
   labels:
     {{- include "mimir.labels" $args | nindent 4 }}
     {{- if (eq $rolloutZone.noDownscale true )}}
-    grafana.com/no-downscale: {{$rolloutZone.noDownscale}}
+    grafana.com/no-downscale: {{ $rolloutZone.noDownscale | quote }}
     {{- else }}
     {{- if (eq $rolloutZone.prepareDownscale true )}}
-    grafana.com/prepare-downscale: {{$rolloutZone.prepareDownscale}}
+    grafana.com/prepare-downscale: {{ $rolloutZone.prepareDownscale | quote }}
     grafana.com/min-time-between-zones-downscale: 12h
     {{- end }}
     {{- end }}
@@ -22,7 +22,7 @@ metadata:
     {{- include "mimir.componentAnnotations" $args | nindent 4 }}
     {{- if $rolloutZone.prepareDownscale }}
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: {{ include "mimir.serverHttpListenPort" . }}
+    grafana.com/prepare-downscale-http-port: {{ include "mimir.serverHttpListenPort" . | quote }}
     {{- end -}}
     {{- if $rolloutZone.downscaleLeader }}
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader

--- a/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/charts/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -11,10 +11,10 @@ metadata:
   labels:
     {{- include "mimir.labels" $args | nindent 4 }}
     {{- if (eq $rolloutZone.noDownscale true )}}
-    grafana.com/no-downscale: {{$rolloutZone.noDownscale}}
+    grafana.com/no-downscale: {{ $rolloutZone.noDownscale | quote }}
     {{- else }}
     {{- if (eq $rolloutZone.prepareDownscale true )}}
-    grafana.com/prepare-downscale: {{$rolloutZone.prepareDownscale}}
+    grafana.com/prepare-downscale: {{ $rolloutZone.prepareDownscale | quote }}
     grafana.com/min-time-between-zones-downscale: 30m
     {{- end }}
     {{- end }}
@@ -22,7 +22,7 @@ metadata:
     {{- include "mimir.componentAnnotations" $args | nindent 4 }}
     {{- if $rolloutZone.prepareDownscale }}
     grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: {{ include "mimir.serverHttpListenPort" . }}
+    grafana.com/prepare-downscale-http-port: {{ include "mimir.serverHttpListenPort" . | quote }}
     {{- end -}}
     {{- if $rolloutZone.downscaleLeader }}
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader

--- a/operations/helm/charts/mimir-distributed/values.yaml
+++ b/operations/helm/charts/mimir-distributed/values.yaml
@@ -800,7 +800,7 @@ alertmanager:
         # If undefined or set to null (the default), no Annotation is set
         downscaleLeader: null
         # -- prepareDownscale adds labels and annotations for the rollout-operator to prepare downscaling: https://github.com/grafana/rollout-operator#how-scaling-up-and-down-works
-        prepareDownscale: false
+        prepareDownscale: true
       # -- Name of the zone, used in labels and selectors. Must follow Kubernetes naming restrictions: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
       - name: zone-b
         # -- nodeselector to restrict where pods of this zone can be placed. E.g.:
@@ -821,7 +821,7 @@ alertmanager:
         # If undefined or set to null (the default), no Annotation is set
         downscaleLeader: null
         # -- prepareDownscale adds labels and annotations for the rollout-operator to prepare downscaling: https://github.com/grafana/rollout-operator#how-scaling-up-and-down-works
-        prepareDownscale: false
+        prepareDownscale: true
       # -- Name of the zone, used in labels and selectors. Must follow Kubernetes naming restrictions: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
       - name: zone-c
         # -- nodeselector to restrict where pods of this zone can be placed. E.g.:
@@ -842,7 +842,7 @@ alertmanager:
         # If undefined or set to null (the default), no Annotation is set
         downscaleLeader: null
         # -- prepareDownscale adds labels and annotations for the rollout-operator to prepare downscaling: https://github.com/grafana/rollout-operator#how-scaling-up-and-down-works
-        prepareDownscale: false
+        prepareDownscale: true
 
 distributor:
   # -- Whether to render the manifests related to the distributor component.
@@ -2338,7 +2338,7 @@ store_gateway:
         # If undefined or set to null (the default), no Annotation is set
         downscaleLeader: null
         # -- prepareDownscale adds labels and annotations for the rollout-operator to prepare downscaling: https://github.com/grafana/rollout-operator#how-scaling-up-and-down-works
-        prepareDownscale: false
+        prepareDownscale: true
       # -- Name of the zone, used in labels and selectors. Must follow Kubernetes naming restrictions: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
       - name: zone-b
         # -- nodeselector to restrict where pods of this zone can be placed. E.g.:
@@ -2359,7 +2359,7 @@ store_gateway:
         # If undefined or set to null (the default), no Annotation is set
         downscaleLeader: null
         # -- prepareDownscale adds labels and annotations for the rollout-operator to prepare downscaling: https://github.com/grafana/rollout-operator#how-scaling-up-and-down-works
-        prepareDownscale: false
+        prepareDownscale: true
       # -- Name of the zone, used in labels and selectors. Must follow Kubernetes naming restrictions: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
       - name: zone-c
         # -- nodeselector to restrict where pods of this zone can be placed. E.g.:
@@ -2380,7 +2380,7 @@ store_gateway:
         # If undefined or set to null (the default), no Annotation is set
         downscaleLeader: null
         # -- prepareDownscale adds labels and annotations for the rollout-operator to prepare downscaling: https://github.com/grafana/rollout-operator#how-scaling-up-and-down-works
-        prepareDownscale: false
+        prepareDownscale: true
 
 compactor:
   # -- Whether to render the manifests related to the compactor component.

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -13,12 +13,12 @@ metadata:
     name: "ingester-zone-a"
     rollout-group: ingester
     zone: zone-a
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -167,12 +167,12 @@ metadata:
     name: "ingester-zone-b"
     rollout-group: ingester
     zone: zone-b
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:
@@ -322,12 +322,12 @@ metadata:
     name: "ingester-zone-c"
     rollout-group: ingester
     zone: zone-c
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/enterprise-https-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -13,8 +13,12 @@ metadata:
     name: "store-gateway-zone-a"
     rollout-group: store-gateway
     zone: zone-a
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -164,8 +168,12 @@ metadata:
     name: "store-gateway-zone-b"
     rollout-group: store-gateway
     zone: zone-b
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -315,8 +323,12 @@ metadata:
     name: "store-gateway-zone-c"
     rollout-group: store-gateway
     zone: zone-c
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -13,12 +13,12 @@ metadata:
     name: "ingester-zone-a"
     rollout-group: ingester
     zone: zone-a
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -158,12 +158,12 @@ metadata:
     name: "ingester-zone-b"
     rollout-group: ingester
     zone: zone-b
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:
@@ -304,12 +304,12 @@ metadata:
     name: "ingester-zone-c"
     rollout-group: ingester
     zone: zone-c
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/gateway-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -13,8 +13,12 @@ metadata:
     name: "store-gateway-zone-a"
     rollout-group: store-gateway
     zone: zone-a
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -155,8 +159,12 @@ metadata:
     name: "store-gateway-zone-b"
     rollout-group: store-gateway
     zone: zone-b
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -297,8 +305,12 @@ metadata:
     name: "store-gateway-zone-c"
     rollout-group: store-gateway
     zone: zone-c
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -13,12 +13,12 @@ metadata:
     name: "ingester-zone-a"
     rollout-group: ingester
     zone: zone-a
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -153,12 +153,12 @@ metadata:
     name: "ingester-zone-b"
     rollout-group: ingester
     zone: zone-b
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:
@@ -294,12 +294,12 @@ metadata:
     name: "ingester-zone-c"
     rollout-group: ingester
     zone: zone-c
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/gateway-nginx-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -13,8 +13,12 @@ metadata:
     name: "store-gateway-zone-a"
     rollout-group: store-gateway
     zone: zone-a
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -150,8 +154,12 @@ metadata:
     name: "store-gateway-zone-b"
     rollout-group: store-gateway
     zone: zone-b
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -287,8 +295,12 @@ metadata:
     name: "store-gateway-zone-c"
     rollout-group: store-gateway
     zone: zone-c
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -13,12 +13,12 @@ metadata:
     name: "ingester-zone-a"
     rollout-group: ingester
     zone: zone-a
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -153,12 +153,12 @@ metadata:
     name: "ingester-zone-b"
     rollout-group: ingester
     zone: zone-b
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:
@@ -294,12 +294,12 @@ metadata:
     name: "ingester-zone-c"
     rollout-group: ingester
     zone: zone-c
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-global-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -13,8 +13,12 @@ metadata:
     name: "store-gateway-zone-a"
     rollout-group: store-gateway
     zone: zone-a
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -150,8 +154,12 @@ metadata:
     name: "store-gateway-zone-b"
     rollout-group: store-gateway
     zone: zone-b
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -287,8 +295,12 @@ metadata:
     name: "store-gateway-zone-c"
     rollout-group: store-gateway
     zone: zone-c
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -13,12 +13,12 @@ metadata:
     name: "ingester-zone-a"
     rollout-group: ingester
     zone: zone-a
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -153,12 +153,12 @@ metadata:
     name: "ingester-zone-b"
     rollout-group: ingester
     zone: zone-b
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:
@@ -294,12 +294,12 @@ metadata:
     name: "ingester-zone-c"
     rollout-group: ingester
     zone: zone-c
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-metamonitoring-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -13,8 +13,12 @@ metadata:
     name: "store-gateway-zone-a"
     rollout-group: store-gateway
     zone: zone-a
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -150,8 +154,12 @@ metadata:
     name: "store-gateway-zone-b"
     rollout-group: store-gateway
     zone: zone-b
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -287,8 +295,12 @@ metadata:
     name: "store-gateway-zone-c"
     rollout-group: store-gateway
     zone: zone-c
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -13,12 +13,12 @@ metadata:
     name: "ingester-zone-a"
     rollout-group: ingester
     zone: zone-a
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -153,12 +153,12 @@ metadata:
     name: "ingester-zone-b"
     rollout-group: ingester
     zone: zone-b
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:
@@ -294,12 +294,12 @@ metadata:
     name: "ingester-zone-c"
     rollout-group: ingester
     zone: zone-c
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/keda-autoscaling-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -13,8 +13,12 @@ metadata:
     name: "store-gateway-zone-a"
     rollout-group: store-gateway
     zone: zone-a
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -150,8 +154,12 @@ metadata:
     name: "store-gateway-zone-b"
     rollout-group: store-gateway
     zone: zone-b
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -287,8 +295,12 @@ metadata:
     name: "store-gateway-zone-c"
     rollout-group: store-gateway
     zone: zone-c
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -13,12 +13,12 @@ metadata:
     name: "ingester-zone-a"
     rollout-group: ingester
     zone: zone-a
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -169,12 +169,12 @@ metadata:
     name: "ingester-zone-b"
     rollout-group: ingester
     zone: zone-b
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:
@@ -326,12 +326,12 @@ metadata:
     name: "ingester-zone-c"
     rollout-group: ingester
     zone: zone-c
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/large-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/large-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -13,8 +13,12 @@ metadata:
     name: "store-gateway-zone-a"
     rollout-group: store-gateway
     zone: zone-a
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -166,8 +170,12 @@ metadata:
     name: "store-gateway-zone-b"
     rollout-group: store-gateway
     zone: zone-b
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -319,8 +327,12 @@ metadata:
     name: "store-gateway-zone-c"
     rollout-group: store-gateway
     zone: zone-c
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -13,12 +13,12 @@ metadata:
     name: "ingester-zone-a"
     rollout-group: ingester
     zone: zone-a
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -155,12 +155,12 @@ metadata:
     name: "ingester-zone-b"
     rollout-group: ingester
     zone: zone-b
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:
@@ -298,12 +298,12 @@ metadata:
     name: "ingester-zone-c"
     rollout-group: ingester
     zone: zone-c
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/openshift-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -13,8 +13,12 @@ metadata:
     name: "store-gateway-zone-a"
     rollout-group: store-gateway
     zone: zone-a
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -152,8 +156,12 @@ metadata:
     name: "store-gateway-zone-b"
     rollout-group: store-gateway
     zone: zone-b
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -291,8 +299,12 @@ metadata:
     name: "store-gateway-zone-c"
     rollout-group: store-gateway
     zone: zone-c
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -13,12 +13,12 @@ metadata:
     name: "ingester-zone-a"
     rollout-group: ingester
     zone: zone-a
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -154,12 +154,12 @@ metadata:
     name: "ingester-zone-b"
     rollout-group: ingester
     zone: zone-b
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:
@@ -296,12 +296,12 @@ metadata:
     name: "ingester-zone-c"
     rollout-group: ingester
     zone: zone-c
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/scheduler-name-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -13,8 +13,12 @@ metadata:
     name: "store-gateway-zone-a"
     rollout-group: store-gateway
     zone: zone-a
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -151,8 +155,12 @@ metadata:
     name: "store-gateway-zone-b"
     rollout-group: store-gateway
     zone: zone-b
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -289,8 +297,12 @@ metadata:
     name: "store-gateway-zone-c"
     rollout-group: store-gateway
     zone: zone-c
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -13,12 +13,12 @@ metadata:
     name: "ingester-zone-a"
     rollout-group: ingester
     zone: zone-a
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -169,12 +169,12 @@ metadata:
     name: "ingester-zone-b"
     rollout-group: ingester
     zone: zone-b
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:
@@ -326,12 +326,12 @@ metadata:
     name: "ingester-zone-c"
     rollout-group: ingester
     zone: zone-c
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/small-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/small-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -13,8 +13,12 @@ metadata:
     name: "store-gateway-zone-a"
     rollout-group: store-gateway
     zone: zone-a
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -166,8 +170,12 @@ metadata:
     name: "store-gateway-zone-b"
     rollout-group: store-gateway
     zone: zone-b
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -319,8 +327,12 @@ metadata:
     name: "store-gateway-zone-c"
     rollout-group: store-gateway
     zone: zone-c
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -13,12 +13,12 @@ metadata:
     name: "ingester-zone-a"
     rollout-group: ingester
     zone: zone-a
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -159,12 +159,12 @@ metadata:
     name: "ingester-zone-b"
     rollout-group: ingester
     zone: zone-b
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:
@@ -306,12 +306,12 @@ metadata:
     name: "ingester-zone-c"
     rollout-group: ingester
     zone: zone-c
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-component-image-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -13,8 +13,12 @@ metadata:
     name: "store-gateway-zone-a"
     rollout-group: store-gateway
     zone: zone-a
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -156,8 +160,12 @@ metadata:
     name: "store-gateway-zone-b"
     rollout-group: store-gateway
     zone: zone-b
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -299,8 +307,12 @@ metadata:
     name: "store-gateway-zone-c"
     rollout-group: store-gateway
     zone: zone-c
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -13,12 +13,12 @@ metadata:
     name: "ingester-zone-a"
     rollout-group: ingester
     zone: zone-a
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -158,12 +158,12 @@ metadata:
     name: "ingester-zone-b"
     rollout-group: ingester
     zone: zone-b
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:
@@ -304,12 +304,12 @@ metadata:
     name: "ingester-zone-c"
     rollout-group: ingester
     zone: zone-c
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -13,8 +13,12 @@ metadata:
     name: "store-gateway-zone-a"
     rollout-group: store-gateway
     zone: zone-a
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -155,8 +159,12 @@ metadata:
     name: "store-gateway-zone-b"
     rollout-group: store-gateway
     zone: zone-b
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -297,8 +305,12 @@ metadata:
     name: "store-gateway-zone-c"
     rollout-group: store-gateway
     zone: zone-c
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -11,12 +11,12 @@ metadata:
     name: "ingester-zone-a"
     rollout-group: ingester
     zone: zone-a
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -148,12 +148,12 @@ metadata:
     name: "ingester-zone-b"
     rollout-group: ingester
     zone: zone-b
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:
@@ -286,12 +286,12 @@ metadata:
     name: "ingester-zone-c"
     rollout-group: ingester
     zone: zone-c
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-legacy-label-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -11,8 +11,12 @@ metadata:
     name: "store-gateway-zone-a"
     rollout-group: store-gateway
     zone: zone-a
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -145,8 +149,12 @@ metadata:
     name: "store-gateway-zone-b"
     rollout-group: store-gateway
     zone: zone-b
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -279,8 +287,12 @@ metadata:
     name: "store-gateway-zone-c"
     rollout-group: store-gateway
     zone: zone-c
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -13,12 +13,12 @@ metadata:
     name: "ingester-zone-a"
     rollout-group: ingester
     zone: zone-a
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -155,12 +155,12 @@ metadata:
     name: "ingester-zone-b"
     rollout-group: ingester
     zone: zone-b
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:
@@ -298,12 +298,12 @@ metadata:
     name: "ingester-zone-c"
     rollout-group: ingester
     zone: zone-c
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-enterprise-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -13,8 +13,12 @@ metadata:
     name: "store-gateway-zone-a"
     rollout-group: store-gateway
     zone: zone-a
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -152,8 +156,12 @@ metadata:
     name: "store-gateway-zone-b"
     rollout-group: store-gateway
     zone: zone-b
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -291,8 +299,12 @@ metadata:
     name: "store-gateway-zone-c"
     rollout-group: store-gateway
     zone: zone-c
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -13,12 +13,12 @@ metadata:
     name: "ingester-zone-a"
     rollout-group: ingester
     zone: zone-a
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -153,12 +153,12 @@ metadata:
     name: "ingester-zone-b"
     rollout-group: ingester
     zone: zone-b
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:
@@ -294,12 +294,12 @@ metadata:
     name: "ingester-zone-c"
     rollout-group: ingester
     zone: zone-c
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-extra-args-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -13,8 +13,12 @@ metadata:
     name: "store-gateway-zone-a"
     rollout-group: store-gateway
     zone: zone-a
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -157,8 +161,12 @@ metadata:
     name: "store-gateway-zone-b"
     rollout-group: store-gateway
     zone: zone-b
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -301,8 +309,12 @@ metadata:
     name: "store-gateway-zone-c"
     rollout-group: store-gateway
     zone: zone-c
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -13,12 +13,12 @@ metadata:
     name: "ingester-zone-a"
     rollout-group: ingester
     zone: zone-a
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -153,12 +153,12 @@ metadata:
     name: "ingester-zone-b"
     rollout-group: ingester
     zone: zone-b
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:
@@ -294,12 +294,12 @@ metadata:
     name: "ingester-zone-c"
     rollout-group: ingester
     zone: zone-c
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-ingress-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -13,8 +13,12 @@ metadata:
     name: "store-gateway-zone-a"
     rollout-group: store-gateway
     zone: zone-a
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -150,8 +154,12 @@ metadata:
     name: "store-gateway-zone-b"
     rollout-group: store-gateway
     zone: zone-b
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -287,8 +295,12 @@ metadata:
     name: "store-gateway-zone-c"
     rollout-group: store-gateway
     zone: zone-c
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -13,12 +13,12 @@ metadata:
     name: "ingester-zone-a"
     rollout-group: ingester
     zone: zone-a
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -154,12 +154,12 @@ metadata:
     name: "ingester-zone-b"
     rollout-group: ingester
     zone: zone-b
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:
@@ -296,12 +296,12 @@ metadata:
     name: "ingester-zone-c"
     rollout-group: ingester
     zone: zone-c
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-component-image-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -13,8 +13,12 @@ metadata:
     name: "store-gateway-zone-a"
     rollout-group: store-gateway
     zone: zone-a
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -151,8 +155,12 @@ metadata:
     name: "store-gateway-zone-b"
     rollout-group: store-gateway
     zone: zone-b
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -289,8 +297,12 @@ metadata:
     name: "store-gateway-zone-c"
     rollout-group: store-gateway
     zone: zone-c
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -13,12 +13,12 @@ metadata:
     name: "ingester-zone-a"
     rollout-group: ingester
     zone: zone-a
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -153,12 +153,12 @@ metadata:
     name: "ingester-zone-b"
     rollout-group: ingester
     zone: zone-b
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:
@@ -294,12 +294,12 @@ metadata:
     name: "ingester-zone-c"
     rollout-group: ingester
     zone: zone-c
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-k8s-1.25-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -13,8 +13,12 @@ metadata:
     name: "store-gateway-zone-a"
     rollout-group: store-gateway
     zone: zone-a
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -150,8 +154,12 @@ metadata:
     name: "store-gateway-zone-b"
     rollout-group: store-gateway
     zone: zone-b
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -287,8 +295,12 @@ metadata:
     name: "store-gateway-zone-c"
     rollout-group: store-gateway
     zone: zone-c
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -13,6 +13,7 @@ metadata:
     name: "alertmanager-zone-a"
     rollout-group: alertmanager
     zone: zone-a
+    grafana.com/prepare-downscale: "true"
   annotations:
     rollout-max-unavailable: "2"
   namespace: "citestns"
@@ -144,6 +145,7 @@ metadata:
     name: "alertmanager-zone-b"
     rollout-group: alertmanager
     zone: zone-b
+    grafana.com/prepare-downscale: "true"
   annotations:
     rollout-max-unavailable: "2"
   namespace: "citestns"
@@ -275,6 +277,7 @@ metadata:
     name: "alertmanager-zone-c"
     rollout-group: alertmanager
     zone: zone-c
+    grafana.com/prepare-downscale: "true"
   annotations:
     rollout-max-unavailable: "2"
   namespace: "citestns"

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -13,12 +13,12 @@ metadata:
     name: "ingester-zone-a"
     rollout-group: ingester
     zone: zone-a
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -139,12 +139,12 @@ metadata:
     name: "ingester-zone-b"
     rollout-group: ingester
     zone: zone-b
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:
@@ -266,12 +266,12 @@ metadata:
     name: "ingester-zone-c"
     rollout-group: ingester
     zone: zone-c
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-logical-multizone-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -13,8 +13,12 @@ metadata:
     name: "store-gateway-zone-a"
     rollout-group: store-gateway
     zone: zone-a
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -135,8 +139,12 @@ metadata:
     name: "store-gateway-zone-b"
     rollout-group: store-gateway
     zone: zone-b
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -257,8 +265,12 @@ metadata:
     name: "store-gateway-zone-c"
     rollout-group: store-gateway
     zone: zone-c
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/operations/helm/tests/test-oss-multizone-values-generated/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -13,6 +13,7 @@ metadata:
     name: "alertmanager-zone-a"
     rollout-group: alertmanager
     zone: zone-a
+    grafana.com/prepare-downscale: "true"
   annotations:
     rollout-max-unavailable: "2"
   namespace: "citestns"
@@ -169,6 +170,7 @@ metadata:
     name: "alertmanager-zone-b"
     rollout-group: alertmanager
     zone: zone-b
+    grafana.com/prepare-downscale: "true"
   annotations:
     rollout-max-unavailable: "2"
   namespace: "citestns"
@@ -325,6 +327,7 @@ metadata:
     name: "alertmanager-zone-c"
     rollout-group: alertmanager
     zone: zone-c
+    grafana.com/prepare-downscale: "true"
   annotations:
     rollout-max-unavailable: "2"
   namespace: "citestns"

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -13,12 +13,12 @@ metadata:
     name: "ingester-zone-a"
     rollout-group: ingester
     zone: zone-a
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -174,12 +174,12 @@ metadata:
     name: "ingester-zone-b"
     rollout-group: ingester
     zone: zone-b
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:
@@ -336,12 +336,12 @@ metadata:
     name: "ingester-zone-c"
     rollout-group: ingester
     zone: zone-c
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-oss-topology-spread-constraints-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -13,8 +13,12 @@ metadata:
     name: "store-gateway-zone-a"
     rollout-group: store-gateway
     zone: zone-a
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -160,8 +164,12 @@ metadata:
     name: "store-gateway-zone-b"
     rollout-group: store-gateway
     zone: zone-b
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -307,8 +315,12 @@ metadata:
     name: "store-gateway-zone-c"
     rollout-group: store-gateway
     zone: zone-c
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -13,12 +13,12 @@ metadata:
     name: "ingester-zone-a"
     rollout-group: ingester
     zone: zone-a
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -153,12 +153,12 @@ metadata:
     name: "ingester-zone-b"
     rollout-group: ingester
     zone: zone-b
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:
@@ -294,12 +294,12 @@ metadata:
     name: "ingester-zone-c"
     rollout-group: ingester
     zone: zone-c
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-requests-and-limits-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -13,8 +13,12 @@ metadata:
     name: "store-gateway-zone-a"
     rollout-group: store-gateway
     zone: zone-a
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -150,8 +154,12 @@ metadata:
     name: "store-gateway-zone-b"
     rollout-group: store-gateway
     zone: zone-b
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -287,8 +295,12 @@ metadata:
     name: "store-gateway-zone-c"
     rollout-group: store-gateway
     zone: zone-c
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -13,12 +13,12 @@ metadata:
     name: "ingester-zone-a"
     rollout-group: ingester
     zone: zone-a
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -153,12 +153,12 @@ metadata:
     name: "ingester-zone-b"
     rollout-group: ingester
     zone: zone-b
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:
@@ -294,12 +294,12 @@ metadata:
     name: "ingester-zone-c"
     rollout-group: ingester
     zone: zone-c
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-ruler-dedicated-query-path-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -13,8 +13,12 @@ metadata:
     name: "store-gateway-zone-a"
     rollout-group: store-gateway
     zone: zone-a
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -150,8 +154,12 @@ metadata:
     name: "store-gateway-zone-b"
     rollout-group: store-gateway
     zone: zone-b
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -287,8 +295,12 @@ metadata:
     name: "store-gateway-zone-c"
     rollout-group: store-gateway
     zone: zone-c
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -13,12 +13,12 @@ metadata:
     name: "ingester-zone-a"
     rollout-group: ingester
     zone: zone-a
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: Parallel
@@ -160,12 +160,12 @@ metadata:
     name: "ingester-zone-b"
     rollout-group: ingester
     zone: zone-b
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:
@@ -308,12 +308,12 @@ metadata:
     name: "ingester-zone-c"
     rollout-group: ingester
     zone: zone-c
-    grafana.com/prepare-downscale: true
+    grafana.com/prepare-downscale: "true"
     grafana.com/min-time-between-zones-downscale: 12h
   annotations:
     rollout-max-unavailable: "50"
     grafana.com/prepare-downscale-http-path: ingester/prepare-shutdown
-    grafana.com/prepare-downscale-http-port: 8080
+    grafana.com/prepare-downscale-http-port: "8080"
     grafana.com/rollout-downscale-leader: $rolloutZone.downscaleLeader
   namespace: "citestns"
 spec:

--- a/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/operations/helm/tests/test-vault-agent-values-generated/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -13,8 +13,12 @@ metadata:
     name: "store-gateway-zone-a"
     rollout-group: store-gateway
     zone: zone-a
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -157,8 +161,12 @@ metadata:
     name: "store-gateway-zone-b"
     rollout-group: store-gateway
     zone: zone-b
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady
@@ -301,8 +309,12 @@ metadata:
     name: "store-gateway-zone-c"
     rollout-group: store-gateway
     zone: zone-c
+    grafana.com/prepare-downscale: "true"
+    grafana.com/min-time-between-zones-downscale: 30m
   annotations:
     rollout-max-unavailable: "50"
+    grafana.com/prepare-downscale-http-path: store-gateway/prepare-shutdown
+    grafana.com/prepare-downscale-http-port: "8080"
   namespace: "citestns"
 spec:
   podManagementPolicy: OrderedReady


### PR DESCRIPTION
#### What this PR does

The bulk of the changes in this PR are related to a helm manifest rendering error related to a type mismatch in the annotations. 

This PR also resolves the following items:
-  removes the `grafana.com/prepare-downscale-http-path` and `grafana.com/prepare-downscale-http-port` references in alertmanager-statefulset.yaml because Alertmanager doesn't have a supported prepare-shutdown path like ingesters and store-gateways.   
- sets the default value of `prepareDownscale` to true for alertmanager and store-gateway as ingester was the only one that had been set to true previously
- updates the annotations to have proper quotes as mentioned above
- updated tests with `make build-helm-tests`

#### Which issue(s) this PR fixes or relates to

Fixes [Comments in PR 6733](https://github.com/grafana/mimir/pull/6733)

#### Checklist

- [x] Tests updated.
- [ ] Documentation added.
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`.
- [ ] [`about-versioning.md`](https://github.com/grafana/mimir/blob/main/docs/sources/mimir/configure/about-versioning.md) updated with experimental features.
